### PR TITLE
Wrap throttled jobs in transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ require 'resque/throttler'
 Or in a Gemfile:
 
 ```ruby
-require 'resque-throttler', :require => 'resque/throttler'
+gem 'resque-throttler', :require => 'resque/throttler'
 ```
 
 Usage

--- a/lib/resque/throttler.rb
+++ b/lib/resque/throttler.rb
@@ -76,9 +76,10 @@ class Resque::Job
   def perform_with_throttler
     if @throttled
       begin
-        # TODO this needs to be wrapped in a transcation
-        redis.hmset("throttler:jobs:#{@throttler_uuid}", "started_at", Time.now.to_i)
-        redis.sadd("throttler:#{queue}_uuids", @throttler_uuid)
+        redis.multi do
+          redis.hmset("throttler:jobs:#{@throttler_uuid}", "started_at", Time.now.to_i)
+          redis.sadd("throttler:#{queue}_uuids", @throttler_uuid)
+        end
         perform_without_throttler
       ensure
         redis.hmset("throttler:jobs:#{@throttler_uuid}", "ended_at", Time.now.to_i)


### PR DESCRIPTION
Hi @malomalo,

I noticed that one of the forks of resque-throttler fixed an issue with throttled queues. I would love to use resque-throttler but this seems like a very important fix. Would you mind merging this PR into master?  I'm happy to make changes to conform it to your best practices.

-eabraham